### PR TITLE
Fix Django version incompatible for Python 3.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.9.5
+django>=1.8,<1.9
 django-debug-toolbar==1.4
 gunicorn==19.4.5
 psycopg2==2.6.1


### PR DESCRIPTION
The current required Django version is 1.9.5 which doesn't support
Python 3.3 which causes the Python 3.3 deployment to fail while
using django-ex git repo.

The requirements.txt is modified to use the latest version of
Django 1.8 (1.8.13) instead. Django 1.8.13 supports Python 2.7,
Python 3.2, 3.3, 3.4 and 3.5.

Signed-off-by: Vu Dinh <vdinh@redhat.com>