### PR TITLE
Add PIP_INDEX_URL option and fix required parameter issue

### DIFF
--- a/openshift/templates/django-postgresql.json
+++ b/openshift/templates/django-postgresql.json
@@ -84,7 +84,13 @@
               "kind": "ImageStreamTag",
               "namespace": "${NAMESPACE}",
               "name": "python:3.4"
-            }
+            },
+            "env": [
+              {
+                  "name": "PIP_INDEX_URL",
+                  "value": "${PIP_INDEX_URL}"
+              }
+            ]
           }
         },
         "output": {
@@ -359,24 +365,28 @@
     {
       "name": "NAMESPACE",
       "displayName": "Namespace",
+      "required": true,
       "description": "The OpenShift Namespace where the ImageStream resides.",
       "value": "openshift"
     },
     {
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
+      "required": true,
       "description": "Maximum amount of memory the Django container can use.",
       "value": "512Mi"
     },
     {
       "name": "MEMORY_POSTGRESQL_LIMIT",
       "displayName": "Memory Limit (PostgreSQL)",
+      "required": true,
       "description": "Maximum amount of memory the PostgreSQL container can use.",
       "value": "512Mi"
     },
     {
       "name": "SOURCE_REPOSITORY_URL",
       "displayName": "Git Repository URL",
+      "required": true,
       "description": "The URL of the repository with your application source code.",
       "value": "https://github.com/openshift/django-ex.git"
     },
@@ -406,22 +416,26 @@
     {
       "name": "DATABASE_SERVICE_NAME",
       "displayName": "Database Service Name",
+      "required": true,
       "value": "postgresql"
     },
     {
       "name": "DATABASE_ENGINE",
       "displayName": "Database Engine",
+      "required": true,
       "description": "Database engine: postgresql, mysql or sqlite (default).",
       "value": "postgresql"
     },
     {
       "name": "DATABASE_NAME",
       "displayName": "Database Name",
+      "required": true,
       "value": "default"
     },
     {
       "name": "DATABASE_USER",
       "displayName": "Database Username",
+      "required": true,
       "value": "django"
     },
     {
@@ -441,6 +455,12 @@
       "description": "Set this to a long random string.",
       "generate": "expression",
       "from": "[\\w]{50}"
+    },
+    {
+      "name": "PIP_INDEX_URL",
+      "displayName": "Custom PyPi Index URL",
+      "description": "The custom PyPi index URL",
+      "value": ""
     }
   ]
 }

--- a/openshift/templates/django.json
+++ b/openshift/templates/django.json
@@ -84,7 +84,13 @@
               "kind": "ImageStreamTag",
               "namespace": "${NAMESPACE}",
               "name": "python:3.4"
-            }
+            },
+            "env": [
+              {
+                  "name": "PIP_INDEX_URL",
+                  "value": "${PIP_INDEX_URL}"
+              }
+            ]
           }
         },
         "output": {
@@ -233,18 +239,21 @@
     {
       "name": "NAMESPACE",
       "displayName": "Namespace",
+      "required": true,
       "description": "The OpenShift Namespace where the ImageStream resides.",
       "value": "openshift"
     },
     {
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
+      "required": true,
       "description": "Maximum amount of memory the container can use.",
       "value": "512Mi"
     },
     {
       "name": "SOURCE_REPOSITORY_URL",
       "displayName": "Git Repository URL",
+      "required": true,
       "description": "The URL of the repository with your application source code.",
       "value": "https://github.com/openshift/django-ex.git"
     },
@@ -303,6 +312,12 @@
       "description": "Set this to a long random string.",
       "generate": "expression",
       "from": "[\\w]{50}"
+    },
+    {
+      "name": "PIP_INDEX_URL",
+      "displayName": "Custom PyPi Index URL",
+      "description": "The custom PyPi index URL",
+      "value": ""
     }
   ]
 }


### PR DESCRIPTION
The new PIP_INDEX_URL parameter is added to allow custom PyPi mirror
URL to be used during the build process.

There are several paramaters that are required but didn't listed as
requested (*). Now, they are marked as required to be explicit.

Signed-off-by: Vu Dinh <vdinh@redhat.com>