### PR TITLE
Updated django-debug-toolbar to 1.5 to fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django>=1.8,<1.9
-django-debug-toolbar==1.4
+django-debug-toolbar==1.5
 gunicorn==19.4.5
 psycopg2==2.6.1
 whitenoise==3.0


### PR DESCRIPTION
On initial run of this I got the error below

    TypeError at /
    process() missing 1 required positional argument: 'stream'

[Related to](https://github.com/jazzband/django-debug-toolbar/issues/856)

Fixed by updating to django-debug-toolbar to 1.5 