### PR TITLE
Add information for pg_config error #70 #94

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,23 +52,28 @@ To run this project in your development machine, follow these steps:
 
 1. (optional) Create and activate a [virtualenv](https://virtualenv.pypa.io/) (you may want to use [virtualenvwrapper](http://virtualenvwrapper.readthedocs.org/)).
 
-2. Fork this repo and clone your fork:
+2. Ensure that the executable `pg_config` is available on your machine. You can check this using `which pg_config`. If not, install the dependency with one of the following.
+  - Mac OS X: `brew install postgresql` using [Homebrew](https://brew.sh/)
+  - Ubuntu: `sudo apt-get install libpq-dev`
+  - [Others](https://stackoverflow.com/a/12037133/8122577)
+
+3. Fork this repo and clone your fork:
 
     `git clone https://github.com/openshift/django-ex.git`
 
-3. Install dependencies:
+4. Install dependencies:
 
     `pip install -r requirements.txt`
 
-4. Create a development database:
+5. Create a development database:
 
     `./manage.py migrate`
 
-5. If everything is alright, you should be able to start the Django development server:
+6. If everything is alright, you should be able to start the Django development server:
 
     `./manage.py runserver`
 
-6. Open your browser and go to http://127.0.0.1:8000, you will be greeted with a welcome page.
+7. Open your browser and go to http://127.0.0.1:8000, you will be greeted with a welcome page.
 
 
 ## Deploying to OpenShift


### PR DESCRIPTION
Add the following consideration to the local development section of the README:

Ensure that the executable `pg_config` is available on your machine. You can check this using `which pg_config`. If not, install the dependency with one of the following.
  - Mac OS X: `brew install postgresql` using [Homebrew](https://brew.sh/)
  - Ubuntu: `sudo apt-get install libpq-dev`
  - [Others](https://stackoverflow.com/a/12037133/8122577)