### PR TITLE
Update psycopg2 to 2.7.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To run this project in your development machine, follow these steps:
 1. (optional) Create and activate a [virtualenv](https://virtualenv.pypa.io/) (you may want to use [virtualenvwrapper](http://virtualenvwrapper.readthedocs.org/)).
 
 2. Ensure that the executable `pg_config` is available on your machine. You can check this using `which pg_config`. If not, install the dependency with one of the following.
-  - Mac OS X: `brew install postgresql` using [Homebrew](https://brew.sh/)
+  - macOS: `brew install postgresql` using [Homebrew](https://brew.sh/)
   - Ubuntu: `sudo apt-get install libpq-dev`
   - [Others](https://stackoverflow.com/a/12037133/8122577)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django>=1.8,<1.9
 django-debug-toolbar==1.5
 gunicorn==19.4.5
-psycopg2==2.6.1
+psycopg2==2.7.3.1
 whitenoise==3.0


### PR DESCRIPTION
Update psycopg2 from 2.6.3 to 2.7.3.1 to support postgsql 10 (psycopg/psycopg2#489).

- https://pypi.python.org/pypi/psycopg2/2.6.1
- https://pypi.python.org/pypi/psycopg2/2.7.3.1

#### changelog between 2.6.3 and 2.7.3.1

- http://initd.org/psycopg/docs/news.html#what-s-new-in-psycopg-2-7-3-1


Closes #103 